### PR TITLE
fix: less aggressive fix for target list showing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# devel
+
+* less aggressive fix for showing the target list
+
 # 5.1.0 (2025-08-31)
 
 * updated for D&D 5.1

--- a/scripts/effect-application.mjs
+++ b/scripts/effect-application.mjs
@@ -14,7 +14,9 @@ export default class EffectiveEAE extends dnd5e.applications.components.EffectAp
    * ChatLog5e#onCardIntersects is private and can’t be modified,
    * so this.visible is always false.
   /** @override */
-  get shouldBuildTargetList() { return true;}
+  get shouldBuildTargetList() {
+    return this.open;
+  }
 
   /* -------------------------------------------- */
   /*  Rendering                                   */


### PR DESCRIPTION
Only show target list when tray is shown. Still cannot toggle visible state, though.