### PR TITLE
Remove obsolete “Remove ‘Apply effect to Actor’” and “Allow Application of Transfer Effets”

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # devel
 
 * removed “Don’t Close Trays on Apply” setting; this is handled by the system’s “Collapse Trays in Chat” setting.
+* removed “Remove ‘Apply effect to Actor’” and “Allow Application of Transfer Effets” setting; the former was a workaround that is no longer needed, and the latter was a workaround for that workaround
 
 # 13.348-5.1.5-1 (2025-09-08)
 

--- a/README.md
+++ b/README.md
@@ -11,13 +11,11 @@ Allows users to use the damage tray for selected tokens that they own, and for t
 ## Settings
 - **Transfer to Target**: Allow users to transfer effects to targets they do not own (off by default).
 - **Damage Target**: Allow users to damage targets that they don't own with the damage tray (off by default).
-- **Allow Application of Transfer Effects**: Allows applying effects that have the “Apply to Actor” option set, e.g. the Rage effect from the SRD; will allow applying these to other actors(!) as well. Will apply a *copy* of the effect. If you set this, you probably want to disable the “Remove ‘Apply Effect to Actor’” setting (on by default).
 - **Delete Instead of Refresh**: Attempting to transfer an effect to an actor that has it already will delete it rather than refreshing its duration (off by default).
 - **Filtering** based on actor type, permissions, and token disposition. This prevents users from seeing and interacting with effects of certain origins, depending on GM preference (no filtering is performed by default).
 - **Multiple Effects with Concentration**: Allow multiple effects to be applied from spells with concentration (off by default).
 - **Use Default Trays**: Adds settings (off by default) to use the default effects and damage trays. Only the features *below* this setting will function if a given tray is in its default mode.
 - **Scroll on Expand**: Scroll chat to bottom when expanding a tray that is at the bottom (experimental, on by default).
-- **Remove 'Apply Effect to Actor'**: On the time of creation (i.e. drag & drop, item grant advancement), remove 'Apply Effect to Actor' from effects on items that have a duration to allow for normal use of the timer (off by default).
 
 ## Additional Features
 - Flags enchantment effects with their spellLevel.

--- a/lang/en.json
+++ b/lang/en.json
@@ -2,8 +2,6 @@
   "EFFECTIVETRAY": {
     "AllowTargetSettingName": "Transfer to Target",
     "AllowTargetSettingHint": "Allow users to transfer effects to targets they do not own.",
-    "AllowTransferSettingName": "Allow Application of Transfer Effects",
-    "AllowTransferSettingHint": "Allows applying effects that have the “Apply to Actor” option set, e.g. the Rage effect from the SRD; will allow applying these to other actors(!) as well. Will apply a copy of the effect. If you set this, you probably want to disable the “Remove ‘Apply Effect to Actor’” setting.",
     "DamageDefaultSettingName": "Use Default Damage Tray",
     "DamageDefaultSettingHint": "Retain default system behavior (only the GM can see damage trays).",
     "DamageTargetSettingName": "Damage Target",
@@ -25,8 +23,6 @@
       "NoActiveGMEffect": "There is no active GM. An active GM is required to create effects on targets you do not own.",
       "NoTarget": "You don't have a target."
     },
-    "RemoveTransferSettingName": "Remove 'Apply Effect to Actor'",
-    "RemoveTransferSettingHint": "On the time of creation (i.e. drag & drop, item grant advancement), remove 'Apply Effect to Actor' from effects on items that have a duration to allow for normal use of the timer.",
     "ScrollOnExpandSettingName": "Scroll on Expand",
     "ScrollOnExpandSettingHint": "Scroll chat to bottom when expanding a tray that is at the bottom.",
     "SystemDefaultSettingName": "Use Default Effects Tray",

--- a/scripts/effective-tray.mjs
+++ b/scripts/effective-tray.mjs
@@ -53,7 +53,6 @@ export class EffectiveTray {
     }
 
     // Misc
-    Hooks.on("preCreateItem", EffectiveTray._removeTransfer);
     Hooks.on("preCreateActiveEffect", EffectiveTray._enchantmentSpellLevel);
   }
 
@@ -78,9 +77,6 @@ export class EffectiveTray {
         } else {
           if (message.getFlag("dnd5e", "roll.type")) return;
           effects = item?.effects.filter(e => (e.type !== "enchantment") && !e.getFlag("dnd5e", "rider"));
-        }
-        if (!game.settings.get(MODULE, "allowTransfer")) {
-          effects = effects?.filter(e => !e.transfer);
         }
         if (!effects?.length || foundry.utils.isEmpty(effects)) return;
         if (!effects.some(e => e.type !== "enchantment")) return;
@@ -329,28 +325,6 @@ export class EffectiveTray {
   /* -------------------------------------------- */
   /*  Misc. Methods                               */
   /* -------------------------------------------- */
-
-  /**
-   * Remove transfer and suspended from all effects with duration
-   * @param {Item} item The item with the effect from which to remove "transfer": true and "disabled": true.
-   */
-  static _removeTransfer(item) {
-    if (!game.settings.get(MODULE, "removeTransfer")) return;
-    const effects = item.effects.contents;
-    if (!effects) return;
-    for (const effect of effects) {
-      if (effect.type === "enchantment") continue;
-      if (effect.getFlag("dnd5e", "rider")) continue;
-      const transfer = effect.transfer;
-      const duration = effect.duration;
-      const disabled = effect.disabled;
-      if (transfer && (duration.seconds || duration.turns || duration.rounds)) {
-        let updates = { "transfer": !transfer };
-        if (disabled) foundry.utils.mergeObject(updates, { "disabled": !disabled });
-        effect.updateSource(updates);
-      };
-    };
-  }
 
   /**
    * Before an effect is created, if it is an enchantment from a spell,

--- a/scripts/settings.mjs
+++ b/scripts/settings.mjs
@@ -49,17 +49,6 @@ export class ModuleSettings {
       onChange: false
     });
 
-    game.settings.register(MODULE, "allowTransfer", {
-      name: "EFFECTIVETRAY.AllowTransferSettingName",
-      hint: "EFFECTIVETRAY.AllowTransferSettingHint",
-      scope: "world",
-      config: true,
-      type: Boolean,
-      default: true,
-      requiresReload: false,
-      onChange: false
-    });
-
     game.settings.register(MODULE, "deleteInstead", {
       name: "EFFECTIVETRAY.DeleteInsteadSettingName",
       hint: "EFFECTIVETRAY.DeleteInsteadSettingHint",
@@ -155,17 +144,6 @@ export class ModuleSettings {
       config: true,
       type: Boolean,
       default: true,
-      requiresReload: false,
-      onChange: false
-    })
-
-    game.settings.register(MODULE, "removeTransfer", {
-      name: "EFFECTIVETRAY.RemoveTransferSettingName",
-      hint: "EFFECTIVETRAY.RemoveTransferSettingHint",
-      scope: "world",
-      config: true,
-      type: Boolean,
-      default: false,
       requiresReload: false,
       onChange: false
     });


### PR DESCRIPTION
The former was a workaround that is no longer needed, and the latter was a workaround for that workaround.